### PR TITLE
Bugfix: Illuminate\Database\MySqlConnection is given to Builder's constructor instead of Illuminate\Contracts\Cache\Repository

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -61,6 +61,16 @@ class Builder extends QueryBuilder
         return $results;
     }
 
+    /**
+     * Get a new instance of the query builder.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function newQuery()
+    {
+        return new static($this->cache, $this->connection, $this->grammar, $this->processor, $this->cacheTag);
+    }
+
 
 
 


### PR DESCRIPTION
Bugfix: Illuminate\Database\MySqlConnection was being passed to Builder's constructor by Illuminate\Database\Query\Builder on line 1890 instead of Illuminate\Contracts\Cache\Repository. newQuery method which is being introduced to Builder is overrides the parent with the correct implementation.
